### PR TITLE
Use uname -m to determine machine type

### DIFF
--- a/firmware/u-boot/fuel_master_u_boot_build.sh
+++ b/firmware/u-boot/fuel_master_u_boot_build.sh
@@ -4,7 +4,7 @@ set -ex
 # Based on:
 # http://wiki.macchiatobin.net/tiki-index.php?page=Build+from+source+-+Bootloader
 
-if [ "$(uname -i)" != 'x86_64' ]; then
+if [ "$(uname -m)" != 'x86_64' ]; then
   echo "ERR: This script only supports 86_64 arch."
   exit 1
 fi

--- a/firmware/uefi/fuel_uefi_build.sh
+++ b/firmware/uefi/fuel_uefi_build.sh
@@ -4,7 +4,7 @@ set -ex
 # Based on:
 # http://wiki.macchiatobin.net/tiki-index.php?page=Build+from+source+-+UEFI+EDK+II
 
-if [ "$(uname -i)" != 'x86_64' ]; then
+if [ "$(uname -m)" != 'x86_64' ]; then
   echo "ERR: This script only supports 86_64 arch."
   exit 1
 fi

--- a/kernel/fuel_master_kernel_build.sh
+++ b/kernel/fuel_master_kernel_build.sh
@@ -4,7 +4,7 @@ set -ex
 # Based on:
 # http://wiki.macchiatobin.net/tiki-index.php?page=Build+from+source+-+Kernel
 
-if [ "$(uname -i)" != 'x86_64' ]; then
+if [ "$(uname -m)" != 'x86_64' ]; then
   echo "ERR: This script only supports 86_64 arch."
   exit 1
 fi

--- a/toolchain/gcc_linaro_install.sh
+++ b/toolchain/gcc_linaro_install.sh
@@ -4,7 +4,7 @@ set -ex
 # Based on:
 # http://wiki.macchiatobin.net/tiki-index.php?page=Toolchain+Installation
 
-if [ "$(uname -i)" != 'x86_64' ]; then
+if [ "$(uname -m)" != 'x86_64' ]; then
   echo "ERR: This script only supports 86_64 arch."
   exit 1
 fi


### PR DESCRIPTION
uname -i returns unknown on Debian Stretch.
uname -m returns x86_64.

The manpage of uname describes -i as not portable.

Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>